### PR TITLE
[oneshot] oneshot-root.service is run after dsme

### DIFF
--- a/services/oneshot-root.service
+++ b/services/oneshot-root.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Oneshot stuff for root
-After=hwclocks.service
+After=dsme.service
 Before=systemd-user-sessions.service
 Requires=dbus.service dsme.service
 


### PR DESCRIPTION
system time is no more set by hwclock.service but dsme does provide it.
oneshot-root-service is started after clock is set (after dsme)

Signed-off-by: Pekka Lundstrom pekka.lundstrom@jollamobile.com
