### PR TITLE
[oneshot-root] Don't rerun oneshot on dsme restart. JB#18250

### DIFF
--- a/services/oneshot-root.service
+++ b/services/oneshot-root.service
@@ -2,7 +2,7 @@
 Description=Oneshot stuff for root
 After=dsme.service
 Before=systemd-user-sessions.service
-Requires=dbus.service dsme.service
+Requires=dbus.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
There is no need to have "Requires=dsme.service" as it only makes oneshot-root to be rerun any time dsme is restarted. We want oneshot to be run once per boot, no more, no less.

Signed-off-by: Pekka Lundstrom pekka.lundstrom@jollamobile.com
